### PR TITLE
Include role action plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The problem is that the `my_intermediate_result` fact is global and is overwritt
 
 ### Proof of concept solution
 
-The proposal in this repository is to call the role with awrapper role around `include_role` called `call` that 
+The proposal in this repository is to call the role with a wrapper role around `include_role` called `call` that 
 maintains a stack of dictionaries. Each time the wrapper is included it completes the following steps:
 
 1. Push the current value of the `local` fact, defaulting to an empty dictionary

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # pieterjanv.localscope - Ansible collection that makes roles behave more like functions
 
 
-This repository contains an Ansible collection that attempts to make Ansible
-roles behave more like functions in typical programming languages.
+An Ansible collection that provides roles with localscope, eager evaluation of
+arguments, and return values.
 
-It allows...
-
-- roles to have **locally scoped facts**, i.e. facts that are only 
+- **locally scoped facts**; facts that are only 
 visible to the role that set them. This aims to solve the problem of global 
 scope in Ansible roles, where intermediate results can be overwritten by 
-included roles,
-- roles to take **arguments that are evaluated eagerly**, rather than the 
-default lazy evaluation. This prevents arguments from evaluating to unintended 
-values when some nested variable name conflicts,
-- roles to **return values**, through the use of `register`.
+included roles.
+- **arguments that are evaluated eagerly**; This prevents arguments from 
+evaluating to unintended  values when some nested variable name conflicts.
+- **return values**; `register` a name to capture the return value of a role.
 
 And it should allow this without changing the way roles are are consumed, i.e. 
 without requiring the consumer to use the plugin directly.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ that any role arguments passed under the `input` key are evaluated eagerly,
 and made available at both `local.input` and as regular variables.
 
 Secondly, an action plugin called `pieterjanv.localscope.set` is provided, 
-that allows a straightforward way of setting the `local` fact.
+that allows a straightforward way of setting the `local` fact. Specifying
+the `register` option sets the value to the specified key instead.
 
 Finally, an action plugin called `pieterjanv.localscope.return` is provided,
 that allows a role to return a value at the `register`ed key.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: pieterjanv
 name: localscope
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/action/include_role.py
+++ b/plugins/action/include_role.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+from ansible.playbook.play import Play
+from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.inventory.manager import InventoryManager
+
+display = Display()
+
+class ActionModule(ActionBase):
+
+    args = None
+    call_args = None
+
+    def run(self, tmp=None, task_vars=None):
+        ''' Wrap Ansible's include_role '''
+        if task_vars is None:
+            task_vars = dict()
+
+        old_local = task_vars.get('local', {})
+
+        args = self._task.args
+        self.args = args
+        call_args = old_local.get('call_args', {})
+        self.call_args = call_args
+        role_name = self.get_include_role_arg('name')
+        allow_duplicates = self.get_include_role_arg('allow_duplicates')
+        public = self.get_include_role_arg('public')
+        rolespec_validate = self.get_include_role_arg('rolespec_validate')
+        args.update({
+            'name': role_name or (task_vars.get('ansible_role_name', None)),
+            'allow_duplicates': allow_duplicates if allow_duplicates is not None else True,
+            'defaults_from': self.get_include_role_arg('defaults_from') or 'main',
+            'handlers_from': self.get_include_role_arg('handlers_from') or 'main',
+            'public': public if public is not None else True,
+            'rolespec_validate': rolespec_validate if rolespec_validate is not None else True,
+            'tasks_from': self.get_include_role_arg('tasks_from') or ('tasks' if role_name is None else 'main'),
+            'vars_from': self.get_include_role_arg('vars_from') or 'main',
+        })
+
+        extra_task_vars = {}
+
+        # set deprecated task vars
+        if (
+            task_vars.get('ansible_role_name', None) == 'pieterjanv.localscope.call' and
+            isinstance(task_vars.get('target', {}), dict)
+        ):
+            for key in ['target', 'input']:
+                v = self._templar.template(task_vars.get('target', {})).get(key, None)
+                if v is not None:
+                    extra_task_vars[key] = v
+                elif key in task_vars:
+                    del task_vars[key]
+
+        input = args.get('input', self._templar.template(task_vars.get('input',
+            old_local.get('input', None)
+        ) if role_name is None else None))
+        if 'input' in args:
+            del args['input']
+        if input is not None:
+            extra_task_vars.update(input)
+
+        pieterjanv_localscope_stack = task_vars.get('pieterjanv_localscope_stack', [])
+        private_locals = old_local.get('_', {})
+        new_local = (
+            {
+                **({ 'input': input } if input is not None else {}),
+                **{
+                    'callee': args.get('name'),
+                    '_': {
+                        **self.get_deprecated_target_arg(
+                            'target',
+                            task_vars,
+                            private_locals,
+                        ),
+                        **self.get_deprecated_target_arg(
+                            'call_args',
+                            task_vars,
+                            private_locals,
+                        ),
+                        **self.get_deprecated_target_arg(
+                            'input',
+                            task_vars,
+                            private_locals,
+                        ),
+                    }
+                },
+            }
+        )
+
+        play = Play.load(
+            {
+                'hosts': task_vars['inventory_hostname'],
+                'gather_facts': 'no',
+                'tasks': [
+                    {
+                        'name': 'push to stack',
+                        'ansible.builtin.set_fact': {
+                            'pieterjanv_localscope_stack': (
+                                pieterjanv_localscope_stack +
+                                [old_local]
+                            )
+                        },
+                    },
+                    {
+                        'name': 'initialize local',
+                        'ansible.builtin.set_fact': {
+                            'local': new_local
+                        },
+                    },
+                    {
+                        'name': 'include role',
+                        'ansible.builtin.include_role': args,
+                        'vars': extra_task_vars,
+                    },
+                    {
+                        'name': 'restore local',
+                        'ansible.builtin.set_fact': {
+                            'local': "{{ pieterjanv_localscope_stack[-1] }}"
+                        },
+                    },
+                    {
+                        'name': 'pop from stack',
+                        'ansible.builtin.set_fact': {
+                            'pieterjanv_localscope_stack': "{{ pieterjanv_localscope_stack[:-1] }}"
+                        },
+                    },
+                ]
+            },
+            variable_manager=self._task._parent._variable_manager,
+            loader=self._task._parent._loader,
+            vars=task_vars,
+        )
+
+        inventory = InventoryManager(self._task._parent._loader)
+        inventory.add_host(task_vars['inventory_hostname'])
+        result = {'changed': False}
+
+        tqm = None
+        try:
+            tqm = TaskQueueManager(
+                inventory=inventory,
+                variable_manager=self._task._parent._variable_manager,
+                loader=self._task._parent._loader,
+                passwords={
+                    'conn_pass': self._play_context.password,
+                    'become_pass': self._play_context.become_pass,
+                }
+            )
+            tqm.run(play)
+        except Exception as e:
+            display.error(f"Error running TaskQueueManager: {e}")
+            result = {'failed': True, 'msg': str(e)}
+        finally:
+            if tqm:
+                tqm.cleanup()
+
+
+        final_result = super(ActionModule, self).run(tmp, task_vars)
+        final_result.update(result)
+        return final_result
+    
+    def get_include_role_arg(self, name):
+        return self.args.get(
+            name,
+            self.args.get('target', {}).get(
+                name,
+                self.call_args.get(name)
+            )
+        )
+    
+    def get_deprecated_target_arg(self, name, task_vars, private_locals):
+        target = self._templar.template(task_vars.get('target', None))
+        if not target or not isinstance(target, dict):
+            return {}
+        value = target.get(name, private_locals.get(name, None))
+        if value is None:
+            return {}
+        return { name: value }
+

--- a/plugins/action/include_role.py
+++ b/plugins/action/include_role.py
@@ -102,7 +102,8 @@ class ActionModule(ActionBase):
                             'pieterjanv_localscope_stack': (
                                 pieterjanv_localscope_stack +
                                 [old_local]
-                            )
+                            ),
+                            'pieterjanv_localscope_output': {},
                         },
                     },
                     {
@@ -137,7 +138,6 @@ class ActionModule(ActionBase):
 
         inventory = InventoryManager(self._task._parent._loader)
         inventory.add_host(task_vars['inventory_hostname'])
-        result = {'changed': False}
 
         tqm = None
         try:
@@ -153,15 +153,15 @@ class ActionModule(ActionBase):
             tqm.run(play)
         except Exception as e:
             display.error(f"Error running TaskQueueManager: {e}")
-            result = {'failed': True, 'msg': str(e)}
+            return { 'changed': False, 'failed': True, 'msg': str(e)}
         finally:
             if tqm:
                 tqm.cleanup()
 
-
-        final_result = super(ActionModule, self).run(tmp, task_vars)
-        final_result.update(result)
-        return final_result
+        return task_vars.get('hostvars', {}).get(
+            task_vars.get('inventory_hostname'),
+            {},
+        ).get('pieterjanv_localscope_output', {})
     
     def get_include_role_arg(self, name):
         return self.args.get(

--- a/plugins/action/return.py
+++ b/plugins/action/return.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleAction, AnsibleActionFail
+from ansible.plugins.action import ActionBase
+from ansible.plugins.loader import action_loader
+from ansible.utils.display import Display
+
+display = Display()
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        ''' Set a return value to a fact reserved for output '''
+        if task_vars is None:
+            task_vars = dict()
+
+        output_name = 'pieterjanv_localscope_output'
+
+        set_task = self._task.copy()
+        set_task.args.clear()
+        set_task._register = output_name
+        set_task.args.update({
+            'updates': self._task.args,
+        })
+        set_plugin = action_loader.get(
+            'pieterjanv.localscope.set',
+            set_task,
+            connection=self._connection,
+            play_context=self._play_context,
+            loader=self._loader,
+            templar=self._templar,
+            shared_loader_obj=self._shared_loader_obj,
+        )
+
+        self._task._register = output_name
+        return set_plugin.run(tmp, task_vars)

--- a/plugins/action/set.py
+++ b/plugins/action/set.py
@@ -37,7 +37,7 @@ class ActionModule(ActionBase):
         hostvars = task_vars.get('hostvars', {}).get(task_vars.get('inventory_hostname', None), None)
         if hostvars is None:
             raise Exception('hostvars not found')
-        return self._update(hostvars.get(self._task.register, {}), updates, recursive)
+        return self._update(hostvars.get(self._task._register, {}), updates, recursive)
 
     def _update(self, target, updates, recursive):
         ''' Apply updates to the target '''
@@ -46,6 +46,5 @@ class ActionModule(ActionBase):
             if recursive and isinstance(value, dict):
                 target[templated_key] = self._update(target.get(key, {}), value, recursive)
             else:
-                display.vvvv('Setting %s to %s on %s' % (templated_key, value, target))
                 target[templated_key] = self._templar.template(value)
         return target

--- a/roles/call/tasks/main.yml
+++ b/roles/call/tasks/main.yml
@@ -7,62 +7,13 @@
     ansible_parent_role_names[0] is not defined
   )"
 
-- name: push to stack
-  ansible.builtin.set_fact:
-    pieterjanv_localscope_stack: "{{
-      (pieterjanv_localscope_stack | default([None]))[:-1] + [local | default({})] + [
-        (
-          { 'input': input } if input is defined else
-          { 'input': local.input } if target.name is not defined and local.call_args.name is not defined and local.input is defined else
-          {}
-        ) | combine({
-          'callee': target.name | default(local.call_args.name | default(ansible_parent_role_names[0])),
-          '_': (
-            (
-              { 'target': target.target } if target.target is defined else
-              { 'target': local._.target } if local._.target is defined else
-              {}
-            ) |
-            combine(
-              { 'input': target.input } if target.input is defined else
-              { 'input': local._.input } if local._.input is defined else
-              {}
-            )
-          )
-        })
-      ]  
-    }}"
-    pieterjanv_localscope_call_args:
-      name: "{{ target.name | default(local.call_args.name | default(ansible_parent_role_names[0])) }}"
-      allow_duplicates: "{{ target.allow_duplicates | default(local.call_args.allow_duplicates | default(true)) }}"
-      defaults_from: "{{ target.defaults_from | default(local.call_args.defaults_from | default('main')) }}"
-      handlers_from: "{{ target.handlers_from | default(local.call_args.handlers_from | default('main')) }}"
-      public: "{{ target.public | default(local.call_args.public | default(false)) }}"
-      rolespec_validate: "{{ target.rolespec_validate | default(local.call_args.rolespec_validate | default(true)) }}"
-      tasks_from: "{{ target.tasks_from | default(local.call_args.tasks_from | default('tasks' if target.name is not defined else 'main')) }}"
-      vars_from: "{{ target.vars_from | default(local.call_args.vars_from | default('main')) }}"
-
-- name: initialize local
-  ansible.builtin.set_fact:
-    local: "{{ pieterjanv_localscope_stack[-1] }}"
-
-- ansible.builtin.include_role:
-    name: "{{ pieterjanv_localscope_call_args.name }}"
-    allow_duplicates: "{{ pieterjanv_localscope_call_args.allow_duplicates }}"
-    defaults_from: "{{ pieterjanv_localscope_call_args.defaults_from }}"
-    handlers_from: "{{ pieterjanv_localscope_call_args.handlers_from }}"
-    public: "{{ pieterjanv_localscope_call_args.public }}"
-    rolespec_validate: "{{ pieterjanv_localscope_call_args.rolespec_validate }}"
-    tasks_from: "{{ pieterjanv_localscope_call_args.tasks_from }}"
-    vars_from: "{{ pieterjanv_localscope_call_args.vars_from }}"
-  vars:
-    target: "{{ local._.target | default(undef()) }}"
-    input: "{{ local._.input | default(undef()) }}"
-
-- name: pop from stack
-  ansible.builtin.set_fact:
-    pieterjanv_localscope_stack: "{{ pieterjanv_localscope_stack[:-1] }}"
-
-- name: restore local
-  ansible.builtin.set_fact:
-    local: "{{ pieterjanv_localscope_stack[-1] }}"
+- pieterjanv.localscope.include_role:
+    name: "{{ target.name | default(local.call_args.name | default(ansible_parent_role_names[0])) }}"
+    allow_duplicates: "{{ target.allow_duplicates | default(local.call_args.allow_duplicates | default(true)) }}"
+    defaults_from: "{{ target.defaults_from | default(local.call_args.defaults_from | default('main')) }}"
+    handlers_from: "{{ target.handlers_from | default(local.call_args.handlers_from | default('main')) }}"
+    public: "{{ target.public | default(local.call_args.public | default(false)) }}"
+    rolespec_validate: "{{ target.rolespec_validate | default(local.call_args.rolespec_validate | default(true)) }}"
+    tasks_from: "{{ target.tasks_from | default(local.call_args.tasks_from | default('tasks' if target.name is not defined else 'main')) }}"
+    vars_from: "{{ target.vars_from | default(local.call_args.vars_from | default('main')) }}"
+    input: "{{ input | default(None) }}"

--- a/test/main.yml
+++ b/test/main.yml
@@ -11,6 +11,11 @@
 
   tasks:
 
+    - name: assert `outer_result.key` is `'value'`
+      ansible.builtin.assert:
+        that:
+          - outer_result.key == 'value'
+
     - name: Import role robust_outer
       ansible.builtin.import_role:
         name: roles/robust_outer
@@ -30,6 +35,12 @@
         name: roles/robust_outer
         input:
           name: test
+      register: my_result
+
+    - name: assert `my_result.key` is `'value'`
+      ansible.builtin.assert:
+        that:
+          - my_result.key == 'value'
 
     - name: Include role using pieterjanv.localscope.include_role, tasks from main
       pieterjanv.localscope.include_role:

--- a/test/main.yml
+++ b/test/main.yml
@@ -7,6 +7,7 @@
       vars:
         input:
           name: test
+        some_var: play
 
   tasks:
 
@@ -24,54 +25,68 @@
         input:
           name: test
 
-    - name: Include role using the call role
-      ansible.builtin.include_role:
-        name: pieterjanv.localscope.call
-      vars:
-        target:
-          name: roles/robust_outer
+    - name: Include role using pieterjanv.localscope.include_role
+      pieterjanv.localscope.include_role:
+        name: roles/robust_outer
         input:
           name: test
 
-    - name: Include role using the call role; tasks from main
-      ansible.builtin.include_role:
-        name: pieterjanv.localscope.call
-      vars:
-        target:
-          name: roles/robust_outer
-          tasks_from: main
+    - name: Include role using pieterjanv.localscope.include_role, tasks from main
+      pieterjanv.localscope.include_role:
+        name: roles/robust_outer
+        tasks_from: main
         input:
           name: test
 
-    - name: Include role using the call role; tasks from tasks
-      ansible.builtin.include_role:
-        name: pieterjanv.localscope.call
-      vars:
-        target:
-          name: roles/robust_outer
-          tasks_from: tasks
+    - name: Include role using pieterjanv.localscope.include_role, tasks from tasks
+      pieterjanv.localscope.include_role:
+        name: roles/robust_outer
+        tasks_from: tasks
         input:
           name: test
 
-    - name: Include role using the call role; test target var can be passed
-      ansible.builtin.include_role:
-        name: pieterjanv.localscope.call
+    - name: Assert role input is evaluated eagerly
       vars:
-        target:
-          name: roles/robust_outer
-          tasks_from: tasks
-          target: target_test
+        a_var: "outer"
+      pieterjanv.localscope.include_role:
+        name: roles/some_role
         input:
-          name: test
+          target: blah
+          some_var: "{{ a_var }}"
 
     - name: test for backwards compatibility
-      pieterjanv.localscope.set:
-        updates:
-          call_args:
-            name: roles/robust_outer
-            tasks_from: tasks
-    - include_role:
-        name: pieterjanv.localscope.call
-      vars:
-        input:
-          name: test
+      ansible.builtin.meta: noop
+    - block:
+
+        - name: Include role using the call role; tasks from tasks
+          ansible.builtin.include_role:
+            name: pieterjanv.localscope.call
+          vars:
+            target:
+              name: roles/robust_outer
+              tasks_from: tasks
+            input:
+              name: test
+
+        - name: Include role using the call role; test target var can be passed
+          ansible.builtin.include_role:
+            name: pieterjanv.localscope.call
+          vars:
+            target:
+              name: roles/robust_outer
+              tasks_from: tasks
+              target: target_test
+            input:
+              name: test
+
+        - name: test using `local.call_args`
+          pieterjanv.localscope.set:
+            updates:
+              call_args:
+                name: roles/robust_outer
+                tasks_from: tasks
+        - include_role:
+            name: pieterjanv.localscope.call
+          vars:
+            input:
+              name: test

--- a/test/main.yml
+++ b/test/main.yml
@@ -1,13 +1,16 @@
 - name: Run tests
   hosts: localhost
   gather_facts: no
+  vars:
+    some_var: play
 
   roles:
     - role: roles/robust_outer
       vars:
+        a_var: "outer"
         input:
           name: test
-        some_var: play
+          some_var: "{{ a_var }}"
 
   tasks:
 
@@ -20,21 +23,28 @@
       ansible.builtin.import_role:
         name: roles/robust_outer
       vars:
+        a_var: "outer"
         input:
           name: test
+          some_var: "{{ a_var }}"
 
     - name: Include role robust_outer
       ansible.builtin.include_role:
         name: roles/robust_outer
       vars:
+        a_var: "outer"
         input:
           name: test
+          some_var: "{{ a_var }}"
 
     - name: Include role using pieterjanv.localscope.include_role
+      vars:
+        a_var: "outer"
       pieterjanv.localscope.include_role:
         name: roles/robust_outer
         input:
           name: test
+          some_var: "{{ a_var }}"
       register: my_result
 
     - name: assert `my_result.key` is `'value'`
@@ -43,26 +53,23 @@
           - my_result.key == 'value'
 
     - name: Include role using pieterjanv.localscope.include_role, tasks from main
+      vars:
+        a_var: "outer"
       pieterjanv.localscope.include_role:
         name: roles/robust_outer
         tasks_from: main
         input:
           name: test
+          some_var: "{{ a_var }}"
 
     - name: Include role using pieterjanv.localscope.include_role, tasks from tasks
+      vars:
+        a_var: "outer"
       pieterjanv.localscope.include_role:
         name: roles/robust_outer
         tasks_from: tasks
         input:
           name: test
-
-    - name: Assert role input is evaluated eagerly
-      vars:
-        a_var: "outer"
-      pieterjanv.localscope.include_role:
-        name: roles/some_role
-        input:
-          target: blah
           some_var: "{{ a_var }}"
 
     - name: test for backwards compatibility
@@ -73,22 +80,26 @@
           ansible.builtin.include_role:
             name: pieterjanv.localscope.call
           vars:
+            a_var: "outer"
             target:
               name: roles/robust_outer
               tasks_from: tasks
             input:
               name: test
+              some_var: "{{ a_var }}"
 
         - name: Include role using the call role; test target var can be passed
           ansible.builtin.include_role:
             name: pieterjanv.localscope.call
           vars:
+            a_var: "outer"
             target:
               name: roles/robust_outer
               tasks_from: tasks
               target: target_test
             input:
               name: test
+              some_var: "{{ a_var }}"
 
         - name: test using `local.call_args`
           pieterjanv.localscope.set:
@@ -99,5 +110,7 @@
         - include_role:
             name: pieterjanv.localscope.call
           vars:
+            a_var: "outer"
             input:
               name: test
+              some_var: "{{ a_var }}"

--- a/test/roles/robust_outer/tasks/main.yml
+++ b/test/roles/robust_outer/tasks/main.yml
@@ -1,1 +1,4 @@
 - pieterjanv.localscope.include_role:
+  register: outer_result
+
+- pieterjanv.localscope.return: "{{ outer_result }}"

--- a/test/roles/robust_outer/tasks/main.yml
+++ b/test/roles/robust_outer/tasks/main.yml
@@ -1,2 +1,1 @@
-- ansible.builtin.include_role:
-    name: pieterjanv.localscope.call
+- pieterjanv.localscope.include_role:

--- a/test/roles/robust_outer/tasks/tasks.yml
+++ b/test/roles/robust_outer/tasks/tasks.yml
@@ -52,13 +52,14 @@
       - local.outer_key == 'value'
 
 - name: include third party role
-  ansible.builtin.include_role:
-    name: pieterjanv.localscope.call
-  vars:
-    target: "{{ { 'name': 'some_role' } | combine({
+  pieterjanv.localscope.include_role: "{{ {
+    'name': 'some_role',
+    'input': {
+      'some_var': local.my_intermediate_result,
+    } | combine({
       'target': local._.target,
-    } if local._.target is defined else {}) }}"
-    some_var: some_value
+    } if local._.target is defined else {})
+  } }}"
 
 - name: assert local scope is still available
   ansible.builtin.assert:

--- a/test/roles/robust_outer/tasks/tasks.yml
+++ b/test/roles/robust_outer/tasks/tasks.yml
@@ -55,11 +55,16 @@
   pieterjanv.localscope.include_role: "{{ {
     'name': 'some_role',
     'input': {
-      'some_var': local.my_intermediate_result,
     } | combine({
       'target': local._.target,
     } if local._.target is defined else {})
   } }}"
+  register: third_party_result
+
+- name: assert `third_party_result` has a default structure
+  ansible.builtin.assert:
+    that:
+      - third_party_result.keys() | length == 2 and third_party_result.keys() | difference(['changed', 'failed']) | length == 0
 
 - name: assert local scope is still available
   ansible.builtin.assert:

--- a/test/roles/robust_outer/tasks/tasks.yml
+++ b/test/roles/robust_outer/tasks/tasks.yml
@@ -65,3 +65,7 @@
   ansible.builtin.assert:
     that:
       - local.my_intermediate_result == "outer"
+
+- name: return `some.nested.key` as a fact
+  pieterjanv.localscope.return:
+    key: "{{ local.some.nested.key }}"

--- a/test/roles/some_role/tasks/main.yml
+++ b/test/roles/some_role/tasks/main.yml
@@ -2,10 +2,13 @@
   ansible.builtin.debug:
     var: target
 
-- name: assert standard variable `some_var` is `'some_value'`
-  ansible.builtin.assert:
-    that:
-      - some_var == "some_value"
+- vars:
+    a_var: "some_role"
+  block:
+    - name: assert standard variable `some_var` is `'outer'`
+      ansible.builtin.assert:
+        that:
+          - some_var == "outer"
 
 - ansible.builtin.set_fact:
     local: some_role


### PR DESCRIPTION
- add `pieterjanv.localscope.include_role` plugin that allows for
  - eager evaluation of arguments
  - returning values
  - locally scoped facts
 - add `pieterjanv.localscope.return` plugin to allow returning values
 - update tests
 - update readme